### PR TITLE
Long usernames overflow fix

### DIFF
--- a/src/client/components/HamburgerMenu/HamburgerMenu.module.css
+++ b/src/client/components/HamburgerMenu/HamburgerMenu.module.css
@@ -48,6 +48,11 @@
   margin-right: 1em;
 }
 
+.menuItem > span {
+  overflow: hidden;
+  text-overflow:ellipsis;
+}
+
 .active {
   text-decoration: underline;
 }

--- a/src/client/components/HamburgerMenu/HamburgerMenu.module.css
+++ b/src/client/components/HamburgerMenu/HamburgerMenu.module.css
@@ -48,7 +48,7 @@
   margin-right: 1em;
 }
 
-.menuItem > span {
+.menuItem > .overflowSpan {
   overflow: hidden;
   text-overflow:ellipsis;
 }

--- a/src/client/components/HamburgerMenu/HamburgerMenu.tsx
+++ b/src/client/components/HamburgerMenu/HamburgerMenu.tsx
@@ -146,7 +146,9 @@ export const HamburgerMenu = ({
                   height={30}
                   alt="profile"
                 />
-                <span>{session.user?.name}</span>
+                <span className={styles.overflowSpan}>
+                  {session.user?.name}
+                </span>
               </div>
               <div className={styles.menuItem} onClick={() => signOut()}>
                 <Image


### PR DESCRIPTION
Small fix that prevents long usernames from overflowing out of the menu.

![image](https://user-images.githubusercontent.com/119818428/227051501-e8ba1008-4312-40d9-8e65-4f4359c70082.png)

![image](https://user-images.githubusercontent.com/119818428/227052222-44097348-348b-43a2-bf94-a78756f24389.png)
